### PR TITLE
bump brfc to match version 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A reference implementation of the Merchant API server is available [here](https:
 
 |     BRFC     |    title     | authors | version |
 | :----------: | :----------: | :-----: | :-----: |
-| 8eeed98377bd | mAPI         | nChain  |   1.3.0 |
+| 625df56f2938 | mAPI         | nChain  |   1.3.0 |
 
 ## Overview
 


### PR DESCRIPTION
Simple change to bump brfc.

Solves https://github.com/bitcoin-sv-specs/brfc-merchantapi/issues/10